### PR TITLE
Support associating crypto addresses to names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XAYA ID
 
-XAYA ID (*Xid*) is an application built on the XAYA platform, that
+XAYA ID (*XID*) is an application built on the XAYA platform, that
 turns each XAYA name into a **secure digital identity** similar to
 [NameID](https://nameid.org/).
 
@@ -13,13 +13,13 @@ for end-to-end encryption.
 
 ## Overview
 
-From a high-level point of view, Xid allows owners of XAYA names to
+From a high-level point of view, XID allows owners of XAYA names to
 **associate metadata** to their names, that **everyone else can read**.
 Due to how XAYA works, **only the owners of names** are able to modify
 the data (through the keys in their wallets).  This ensures that the data
 can be trusted by everyone.
 
-There are two main types of data that can be associated with names:
+There are two types of data that can be associated with names at the moment:
 
 - **Signer addresses** can be used to enable authentication within applications.
   These are ordinary XAYA addresses from the user's wallet; to authenticate with
@@ -29,18 +29,22 @@ There are two main types of data that can be associated with names:
   signers (valid generally for all applications), or they can be set
   specifically for certain applications.
 
+- **Crypto addresses** in general (i.e. for other coins or tokens), so that
+  assets can be sent on another blockchain *to a XAYA name*.
+
+We also plan to support this in the future:
+
 - **Fingerprints of encryption keys** can be associated to names as well.
   This allows the secure and trusted exchange of keys, e.g. for signed emails
   ([GPG](https://gnupg.org/)) or messaging ([OTR](https://otr.cypherpunks.ca/)).
-  *This is not yet implemented in Xid, but will come in the future.*
 
 ## Technical Details
 
 More details can be found in specific documents:
 
-- [Xid game](doc/game.md): Details about the game state and move format
-  for Xid as game on the XAYA platform.
+- [XID game](doc/game.md): Details about the game state and move format
+  for XID as game on the XAYA platform.
 - [RPC interface](doc/rpc.md): The JSON format for game states and the RPC
-  interface of the Xid daemon.
+  interface of the XID daemon.
 - [Authentication](doc/auth.md): How the authentication protocol with a signer
   key works.

--- a/doc/game.md
+++ b/doc/game.md
@@ -1,16 +1,18 @@
-# The Xid Game State and Move Format
+# The XID Game State and Move Format
 
 This document gives a technical description of the underlying XAYA "game"
-for Xid.  In particular, the [game state](#game-state)
+for XID.  In particular, the [game state](#game-state)
 and [format for moves](#moves).
 
 ## <a id="game-state">Game State</a>
 
-Internally, the state of Xid is tracked in an
+Internally, the state of XID is tracked in an
 **[SQLite](https://sqlite.org/) database** as provided by the
 [`SQLiteGame`](https://github.com/xaya/libxayagame/blob/master/xayagame/sqlitegame.hpp)
 framework.  The exact format can be found in
 [`schema.sql`](https://github.com/xaya/xid/blob/master/src/schema.sql).
+
+### Signer Keys
 
 Associations of *signer keys* are tracked by a table that contains triplets
 of XAYA names, applications and signer addresses.  For each name,
@@ -20,7 +22,7 @@ column may be `NULL`.  Addresses in such rows are *global signers* instead of
 being bound to particular applications.
 
 Applications are identified by a string.  The developer of a particular
-Xid-enabled application has to make sure that the string is unique.
+XID-enabled application has to make sure that the string is unique.
 For instance, it can be based on a XAYA game ID with registered `g/` name,
 or it can be based on a website's domain name.
 
@@ -29,11 +31,18 @@ not be used by a real-world application (as it is not descriptive / specific).
 This is *not the same* as a `NULL` value, which represents global signers
 instead!
 
+### Crypto Addresses
+
+Associations of crypto addresses to names are tracked simply by a table
+that has rows of (name, crypto key, crypto address) triplets.  In that table,
+(name, crypto key) is unique, i.e. there can be at most one address for
+each "type" of crypto and name.
+
 ## <a id="moves">Move Format</a>
 
 [Moves](https://github.com/xaya/xaya_docs/blob/master/games.md#moves)
-in Xid allow owners of XAYA names to change the data associated with their
-names in the Xid state.
+in XID allow owners of XAYA names to change the data associated with their
+names in the XID state.
 
 The move data itself must be a **JSON object** of the following form:
 
@@ -46,8 +55,18 @@ The move data itself must be a **JSON object** of the following form:
               APP1: [ADDR1, ADDR2, ...],
               ...
             }
+        },
+      "ca":
+        {
+          CRYPTO1: CRYPTOADDR1,
+          ...
         }
     }
+
+Each of the top-level fields is optional.  When given, they specify
+corresponding updates for the categories of data stored in XID.
+
+### Signer Keys
 
 If `s.g` is present, then the list of **global signers** for the name making
 the move is set precisely to the given array of strings.  Similarly, for each
@@ -61,3 +80,17 @@ a key in `s.a`, then the list of global signers or signers for that application
 Other keys in the top-level object or in `s` are ignored, as are values
 that do not have the correct format (object, array, string).  All correctly
 formatted parts of the move are still executed in that case.
+
+### Crypto Addresses
+
+For each `ca.CRYPTO`n field present, the address associated with the
+move's name for the given type of crypto is updated.
+
+If the `CRYPTOADDR`n is `null`, then the association is removed (i.e. there is
+no longer an address stored for that crypto).  If `CRYPTOADDR`n is a string,
+then an association to that string is created or an existing association
+updated.  Otherwise (the value is neither `null` nor a string), nothing is done.
+
+**NOTE:**  XID does not interpret either the crypto key or address in any
+way.  As long as both are strings, XID performs the update without e.g.
+validating that the address is valid for the given type of crypto.

--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -1,12 +1,12 @@
-# Xid's RPC Interface
+# XID's RPC Interface
 
-This document describes the [JSON format](#json) of the Xid state
+This document describes the [JSON format](#json) of the XID state
 that is used in its RPC interface, as well as the available
 [RPC methods](#rpc) themselves.
 
 ## <a id="json">JSON Format of the Game State</a>
 
-For communication with the Xid daemon, all data is encoded
+For communication with the XID daemon, all data is encoded
 in the [JSON format](https://json.org/).
 
 ### <a id="json-one-name">Data for Names</a>
@@ -25,7 +25,13 @@ following format:
             "addresses": [ADDR1, ADDR2, ...]
           },
           ...
-        ]
+        ],
+      "addresses":
+        {
+          CRYPTO1: CRYPTOADDR1,
+          CRYPTO2: CRYPTOADDR2,
+          ...
+        },
     }
 
 In particular, the `signers` field holds information about registered
@@ -35,6 +41,12 @@ Application-specific signers are given in objects with the application specified
 as a string (which may be `""`).
 All `GLOBAL`n and `ADDR`n signer addresses are XAYA addresses encoded as
 strings.
+
+The `addresses` field holds crypto addresses that the user has associated
+for other coins and tokens.  Each `CRYPTO`n is a string that identifies the
+coin/token (e.g. `btc`), with the `CRYPTOADDR`n being the corresponding address
+also as a string.  The individual keys and formats for addresses are not
+defined (or interpreted) further by XID itself.
 
 ### <a id="json-full">Full Game State</a>
 
@@ -59,7 +71,7 @@ The corresponding `DATA`n values are JSON objects with the
 
 ## <a id="rpc">RPC Methods</a>
 
-When run, the Xid daemon `xid` exposes a
+When run, the XID daemon `xid` exposes a
 **[JSON-RPC 2.0](https://www.jsonrpc.org/)** interface
 over HTTP on a local port (the port number is specified in its invocation).
 
@@ -67,7 +79,7 @@ All methods accept arguments in the **keyword-form**.
 
 ### Standard Methods from `libxayagame`
 
-Since Xid is based on
+Since XID is based on
 [`libxayagame`](https://github.com/xaya/libxayagame),
 it has the standard methods from its
 [`GameRpcServer`](https://github.com/xaya/libxayagame/blob/master/xayagame/gamerpcserver.hpp).
@@ -75,9 +87,9 @@ Those methods can be used for very basic operations.
 
 #### <a id="getcurrentstate">`getcurrentstate`</a>
 
-This method retrieves information about the current state of Xid.  This
+This method retrieves information about the current state of XID.  This
 includes the [full state](#json-full) as well as general information about the
-state of the Xid daemon (e.g. how far it is synced to the blockchain).
+state of the XID daemon (e.g. how far it is synced to the blockchain).
 
 The returned data is a JSON object of the following form:
 
@@ -93,8 +105,8 @@ The returned data is a JSON object of the following form:
 Here, the placeholders have the following meanings:
 
 - **`CHAIN`** defines on which chain (`main`, `test` or `regtest`) the
-  Xid daemon is running.
-- **`STATE`** is the current syncing state of the Xid daemon.  It is typically
+  XID daemon is running.
+- **`STATE`** is the current syncing state of the XID daemon.  It is typically
   `catching-up` while the daemon is still syncing or `up-to-date` if it is
   synced to the latest block.
 - **`BLOCK`** is the block hash to which the current state corresponds.
@@ -103,23 +115,23 @@ Here, the placeholders have the following meanings:
 
 #### `waitforchange`
 
-This method blocks until the state of the Xid daemon changes (typically because
+This method blocks until the state of the XID daemon changes (typically because
 a new block has been processed).  It returns the *block hash* of the new best
 block as string.
 
 In exceptional situations, this method may also return JSON `null` instead,
 if no new best block is known.  This happens if the connected XAYA Core daemon
-does not even have blocks until the initial state of Xid yet.
+does not even have blocks until the initial state of XID yet.
 
 #### `stop`
 
-This is a JSON-RPC *notification* and simply requests the Xid daemon
+This is a JSON-RPC *notification* and simply requests the XID daemon
 to shut down cleanly.
 
 ### Data Retrieval
 
 In addition to the generic [`getcurrentstate`](#getcurrentstate) method which
-returns the full game state, Xid also exposes more specific methods for
+returns the full game state, XID also exposes more specific methods for
 retrieving certain parts of the game state.  Where possible, these methods
 should be used, as they allow more efficient access to the required data.
 
@@ -132,7 +144,7 @@ of a JSON object otherwise like [`getcurrentstate`](#getcurrentstate).
 
 ### Authentication Credentials
 
-Xid has special RPC methods supporting its use for
+XID has special RPC methods supporting its use for
 [user authentication](auth.md).  They are able to construct credentials,
 sign them and verify whether or not given credentials are valid.
 
@@ -229,7 +241,7 @@ values:
 #### `authwithwallet`
 
 This method constructs *and signs* authentication credentials using
-the wallet of the attached Xaya Core daemon.  To use it, Xid has to
+the wallet of the attached Xaya Core daemon.  To use it, XID has to
 be started with `--allow_wallet`.
 
 The `name`, `application` and `data` have to be passed as arguments.

--- a/ejabberd/tests/integration.py
+++ b/ejabberd/tests/integration.py
@@ -155,18 +155,17 @@ class XidAuthTest (XidTest):
     # Verify that the signers are set correctly (just in case).
     for n in self.testNames:
       xayaName = self.decodeName (n)
-      self.assertEqual (self.getRpc ("getnamestate", name=xayaName), {
-        "signers": [{"addresses": [self.addr]}],
-      })
-    self.assertEqual (self.getRpc ("getnamestate", name="nosigner"), {
-      "signers":
-        [
-          {
-            "application": "other",
-            "addresses": [self.addr],
-          },
-        ],
-    })
+      self.assertEqual (self.getRpc ("getnamestate", name=xayaName)["signers"],
+        [{"addresses": [self.addr]}],
+      )
+    self.assertEqual (self.getRpc ("getnamestate", name="nosigner")["signers"],
+      [
+        {
+          "application": "other",
+          "addresses": [self.addr],
+        },
+      ]
+    )
 
     # Now we can perform the main test with a running xidauth script.
     self.mainLogger.info ("Starting xidauth script...")

--- a/gametest/Makefile.am
+++ b/gametest/Makefile.am
@@ -2,6 +2,7 @@ TEST_LIBRARY = \
   xidtest.py
 
 REGTESTS = \
+  address_update.py \
   allow_wallet.py \
   auth.py \
   authwithwallet.py \

--- a/gametest/address_update.py
+++ b/gametest/address_update.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2019 The Xaya developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from xidtest import XidTest
+
+"""
+Tests basic move processing for updating the crypto-address associations.
+"""
+
+
+class AddressUpdateTest (XidTest):
+
+  def expectAddresses (self, expected):
+    """
+    Retrieves the current game state and asserts that the addresses
+    associated to names match the ones given in the expected dictionary.
+    """
+
+    nmState = self.getGameState ()["names"]
+    self.assertEqual (len (nmState), len (expected))
+
+    for nm, s in nmState.iteritems ():
+      assert nm in expected
+      self.assertEqual (s["addresses"], expected[nm])
+
+  def run (self):
+    self.generate (101)
+    self.expectAddresses ({})
+
+    self.sendMove ("foo", {
+      "ca": {"btc": "1foo", "eth": "0xfoo"},
+    })
+    self.sendMove ("bar", {
+      "ca": {"btc": None, "chi": "Cabcdef"},
+    })
+    self.generate (1)
+    self.expectAddresses ({
+      "foo":
+        {
+          "btc": "1foo",
+          "eth":  "0xfoo",
+        },
+      "bar":
+        {
+          "chi": "Cabcdef",
+        },
+    })
+
+    self.sendMove ("foo", {
+      "ca": {"eth": None},
+    })
+    self.sendMove ("bar", {
+      "ca": {"chi": None},
+    })
+    self.generate (1)
+    self.expectAddresses ({
+      "foo":
+        {
+          "btc": "1foo",
+        },
+    })
+
+
+if __name__ == "__main__":
+  AddressUpdateTest ().main ()

--- a/gametest/auth.py
+++ b/gametest/auth.py
@@ -50,23 +50,20 @@ class AuthTest (XidTest):
     }})
     self.sendMove ("", {"s": {"g": [self.addrGeneral]}})
     self.generate (1)
-    self.assertEqual (self.getRpc ("getnamestate", name="domob"), {
-      "signers":
-        [
-          {"addresses": [self.addrGeneral, "invalid just for fun"]},
-          {
-            "application": "",
-            "addresses": [self.addrEmpty],
-          },
-          {
-            "application": "app",
-            "addresses": [self.addrApp],
-          },
-        ],
-    })
-    self.assertEqual (self.getRpc ("getnamestate", name=""), {
-      "signers": [{"addresses": [self.addrGeneral]}],
-    })
+    self.assertEqual (self.getRpc ("getnamestate", name="domob")["signers"], [
+      {"addresses": [self.addrGeneral, "invalid just for fun"]},
+      {
+        "application": "",
+        "addresses": [self.addrEmpty],
+      },
+      {
+        "application": "app",
+        "addresses": [self.addrApp],
+      },
+    ])
+    self.assertEqual (self.getRpc ("getnamestate", name="")["signers"], [
+      {"addresses": [self.addrGeneral]},
+    ])
 
     self.testGetAuthMessage ()
     self.testAuthDataErrors ()

--- a/gametest/getnamestate.py
+++ b/gametest/getnamestate.py
@@ -25,8 +25,12 @@ class GetNameStateTest (XidTest):
         [
           {"addresses": [addr]},
         ],
+      "addresses": {},
     })
-    self.assertEqual (self.getRpc ("getnamestate", name="foo"), {"signers": []})
+    self.assertEqual (self.getRpc ("getnamestate", name="foo"), {
+      "signers": [],
+      "addresses": {},
+    })
 
 
 if __name__ == "__main__":

--- a/src/moveprocessor.hpp
+++ b/src/moveprocessor.hpp
@@ -30,9 +30,15 @@ private:
   void ProcessOne (const Json::Value& obj);
 
   /**
-   * Tries to process an update to the signers in the move (if one is present).
+   * Tries to process an update to the signers in the move with the given
+   * describing object, if it is not null.
    */
-  void HandleSignerUpdate (const std::string& name, const Json::Value& mv);
+  void HandleSignerUpdate (const std::string& name, const Json::Value& obj);
+
+  /**
+   * Tries to process an update to the crypto addresses.
+   */
+  void HandleAddressUpdate (const std::string& name, const Json::Value& obj);
 
 public:
 

--- a/src/moveprocessor_tests.cpp
+++ b/src/moveprocessor_tests.cpp
@@ -40,13 +40,17 @@ protected:
   }
 
   /**
-   * Expects that the state of the given name as JSON matches the given
-   * expected data (string that is parsed as JSON).
+   * Expects that the state of the given name and indexed by the given
+   * key (i.e. a particular subresult of it, like signers) as JSON matches
+   * the given expected data (string that is parsed as JSON).
    */
   void
-  ExpectNameState (const std::string& name, const std::string& expectedStr)
+  ExpectNameState (const std::string& name, const std::string& key,
+                   const std::string& expectedStr)
   {
-    EXPECT_TRUE (JsonEquals (GetNameState (GetDb (), name), expectedStr));
+    const auto actual = GetNameState (GetDb (), name);
+    CHECK (actual.isMember (key));
+    EXPECT_TRUE (JsonEquals (actual[key], expectedStr));
   }
 
 };
@@ -134,21 +138,18 @@ TEST_F (UpdateSignerTests, BasicUpdate)
     }
   ])");
 
-  ExpectNameState ("domob", R"(
-    {
-      "signers":
-        [
-          {"addresses": ["new global 1", "new global 2"]},
-          {
-            "application": "app",
-            "addresses": ["new app"]
-          },
-          {
-            "application": "other",
-            "addresses": ["new other"]
-          }
-        ]
-    }
+  ExpectNameState ("domob", "signers", R"(
+    [
+      {"addresses": ["new global 1", "new global 2"]},
+      {
+        "application": "app",
+        "addresses": ["new app"]
+      },
+      {
+        "application": "other",
+        "addresses": ["new other"]
+      }
+    ]
   )");
 }
 
@@ -167,16 +168,13 @@ TEST_F (UpdateSignerTests, ClearingGlobal)
     }
   ])");
 
-  ExpectNameState ("domob", R"(
-    {
-      "signers":
-        [
-          {
-            "application": "app",
-            "addresses": ["app"]
-          }
-        ]
-    }
+  ExpectNameState ("domob", "signers", R"(
+    [
+      {
+        "application": "app",
+        "addresses": ["app"]
+      }
+    ]
   )");
 }
 
@@ -196,17 +194,14 @@ TEST_F (UpdateSignerTests, ClearingApp)
     }
   ])");
 
-  ExpectNameState ("domob", R"(
-    {
-      "signers":
-        [
-          {"addresses": ["global"]},
-          {
-            "application": "other",
-            "addresses": ["other"]
-          }
-        ]
-    }
+  ExpectNameState ("domob", "signers", R"(
+    [
+      {"addresses": ["global"]},
+      {
+        "application": "other",
+        "addresses": ["other"]
+      }
+    ]
   )");
 }
 
@@ -229,17 +224,14 @@ TEST_F (UpdateSignerTests, OtherNameUntouched)
     }
   ])");
 
-  ExpectNameState ("domob", R"(
-    {
-      "signers":
-        [
-          {"addresses": ["global"]},
-          {
-            "application": "app",
-            "addresses": ["app"]
-          }
-        ]
-    }
+  ExpectNameState ("domob", "signers", R"(
+    [
+      {"addresses": ["global"]},
+      {
+        "application": "app",
+        "addresses": ["app"]
+      }
+    ]
   )");
 }
 
@@ -262,17 +254,14 @@ TEST_F (UpdateSignerTests, EmptyApp)
     }
   ])");
 
-  ExpectNameState ("domob", R"(
-    {
-      "signers":
-        [
-          {"addresses": ["new global"]},
-          {
-            "application": "",
-            "addresses": ["new app"]
-          }
-        ]
-    }
+  ExpectNameState ("domob", "signers", R"(
+    [
+      {"addresses": ["new global"]},
+      {
+        "application": "",
+        "addresses": ["new app"]
+      }
+    ]
   )");
 }
 
@@ -303,20 +292,17 @@ TEST_F (UpdateSignerTests, InvalidStuffIgnored)
     }
   ])");
 
-  ExpectNameState ("domob", R"(
-    {
-      "signers":
-        [
-          {
-            "application": "bar",
-            "addresses": ["addr 1", "addr 2"]
-          },
-          {
-            "application": "xyz",
-            "addresses": ["addr 3"]
-          }
-        ]
-    }
+  ExpectNameState ("domob", "signers", R"(
+    [
+      {
+        "application": "bar",
+        "addresses": ["addr 1", "addr 2"]
+      },
+      {
+        "application": "xyz",
+        "addresses": ["addr 3"]
+      }
+    ]
   )");
 }
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -2,6 +2,8 @@
 -- Distributed under the MIT software license, see the accompanying
 -- file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+-- =============================================================================
+
 -- The mapping between Xaya names that have been registered for Xid and
 -- the signer keys that are allowed for them.  Each Xaya name can have
 -- multiple valid signer keys, which is represented by multiple rows
@@ -26,3 +28,23 @@ CREATE TABLE IF NOT EXISTS `signers` (
 -- addresses.  But since the number of addresses and applications for one
 -- name is likely very small, such an index is not really necessary.
 CREATE INDEX IF NOT EXISTS `signers_name` ON `signers` (`name`);
+
+-- =============================================================================
+
+-- Data about associated crypto addresses with names.
+CREATE TABLE IF NOT EXISTS `addresses` (
+
+  -- The Xaya name for which the association is.
+  `name` TEXT NOT NULL,
+
+  -- Identifier for the crypto token/coin that this represents.
+  `key` TEXT NOT NULL,
+
+  -- The associated address/value.
+  `address` TEXT NOT NULL,
+
+  PRIMARY KEY (`name`, `key`)
+
+);
+
+-- =============================================================================


### PR DESCRIPTION
This implements #3:  In addition to the signer keys, names can also define associations of "crypto addresses".  Those are simply string->string mappings, meant to be of the form e.g. "btc" -> "1someAddress", "eth" -> "0xabcdef" and the likes.  Each name can have at most one address for each crypto coin/token.

(Note that this could in theory also be used e.g. to publish one's email address or other unique identifier, although it is not meant for it.  It is not ideal for publishing fingerprints, though, as for them we might want to support multiple valid fingerprints for a particular user/application - like the signers.)